### PR TITLE
Fix time fractional day calculation occasional bug

### DIFF
--- a/CANYONB.R
+++ b/CANYONB.R
@@ -126,7 +126,7 @@ CANYONB <- function(date,lat,lon,pres,temp,psal,doxy,param,epres,etemp,epsal,edo
   date=as.POSIXlt(date,tz="UTC") #decimal year from date
   year=format(date,"%Y") # get year
   # and add fractional day
-  year=as.numeric(year)+as.double(date-as.POSIXlt(paste0(year,"-01-01 00:00"),format="%Y-%m-%d %H:%M",tz="UTC"))/365
+  as.numeric(year)+as.double(difftime(date, as.POSIXlt(paste0(year,"-01-01 00:00"),format="%Y-%m-%d %H:%M",tz="UTC"), units = "days"))/365
   
   # Latitude: new lat with Polar shift ("Bering Strait prolongation")
   # points for Arctic basin 'West' of Lomonossov ridge (along ca. -037° / 143° E)


### PR DESCRIPTION
Replace date subtraction with a difftime function (for the part where  afarctional day is added to the year time). Otherwise, date subtraction leads to values whose unit is seconds instead of days (which happens when one of the vector's date values is January 1st).